### PR TITLE
changing width of the Facebook iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
       </div>
       <div class="col-lg-6">
         <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fyoungartreading%2F&tabs=timeline&width=500&height=500&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId"
-        width="500" height="500" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+        width="400" height="500" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
       </div>
     </div>
 


### PR DESCRIPTION
In order to stop the bounds breaking on some mobile devices.

before (using a pixel 2):

![before](https://user-images.githubusercontent.com/8792202/54356902-a4f18680-4654-11e9-8fa8-88eec6cddc46.jpeg)
